### PR TITLE
Make min prompt progress delay configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,11 @@
 					"default": 120,
 					"description": "Show status bar during prompt processing when estimated remaining time exceeds this many seconds. Set to 0 to disable. Prompt processing time is estimated assuming quadratic scaling with prompt length."
 				},
+				"llamaCopilot.minPromptProgressElapsedMs": {
+					"type": "number",
+					"default": 10000,
+					"description": "Minimum milliseconds of prompt processing before showing progress. Lower this to see progress on faster models. Set to 0 to show progress immediately."
+				},
 				"llamaCopilot.enableCursorRules": {
 					"type": "boolean",
 					"default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,6 +56,14 @@ export function getPromptProgressStatusBarThresholdSeconds(): number {
 }
 
 /**
+ * Minimum milliseconds of prompt processing before showing progress.
+ * Default 10000 (10 seconds). Set to 0 to show progress immediately.
+ */
+export function getMinPromptProgressElapsedMs(): number {
+	return getConfig().get<number>('minPromptProgressElapsedMs', 10000);
+}
+
+/**
  * Check if cursor rules feature is enabled.
  */
 export function isCursorRulesEnabled(): boolean {

--- a/src/promptProgressEstimate.ts
+++ b/src/promptProgressEstimate.ts
@@ -1,5 +1,5 @@
-/** Do not show status bar before this many ms of prompt processing have elapsed. */
-export const MIN_ELAPSED_MS = 10_000;
+/** Do not show status bar before this many ms of prompt processing have elapsed. Use getMinPromptProgressElapsedMs() from config. */
+export const DEFAULT_MIN_ELAPSED_MS = 10_000;
 
 export interface PromptProgressInput {
 	total: number;
@@ -16,16 +16,17 @@ export interface PromptProgressEstimateResult {
 /**
  * Estimate remaining prompt processing time using quadratic scaling (time ∝ processed²).
  * Returns whether to show the status bar, remaining ms, and a quadratic-corrected display percent.
- * Status bar is shown only when at least MIN_ELAPSED_MS have passed and estimated remaining >= threshold.
+ * Status bar is shown only when at least minElapsedMs have passed and estimated remaining >= threshold.
  */
 export function estimatePromptProgress(
 	input: PromptProgressInput,
-	thresholdSeconds: number
+	thresholdSeconds: number,
+	minElapsedMs: number = DEFAULT_MIN_ELAPSED_MS
 ): PromptProgressEstimateResult {
 	if (thresholdSeconds <= 0) {
 		return { showStatusBar: false, remainingMs: undefined, percent: undefined };
 	}
-	if (input.time_ms < MIN_ELAPSED_MS) {
+	if (input.time_ms < minElapsedMs) {
 		return { showStatusBar: false, remainingMs: undefined, percent: undefined };
 	}
 	if (input.total <= 0 || input.processed < 1) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -4,7 +4,7 @@ import { EndpointsConfig } from './types';
 import { RuleManager } from './cursor-rules/ruleManager';
 import { CursorRulesTool, CURSOR_RULES_TOOL_NAME, resolveAndFormatRules } from './cursor-rules/index';
 import { logRulesMatching, logToolCall, logToolCallResult } from './logger';
-import { getRequestTimeoutMs, getPromptProgressStatusBarThresholdSeconds, isCursorRulesEnabled as isCursorRulesEnabledConfig } from './config';
+import { getRequestTimeoutMs, getPromptProgressStatusBarThresholdSeconds, getMinPromptProgressElapsedMs, isCursorRulesEnabled as isCursorRulesEnabledConfig } from './config';
 import { estimatePromptProgress, formatRemaining } from './promptProgressEstimate';
 import {
 	parseModelId,
@@ -301,9 +301,11 @@ export class LlamaCopilotChatProvider implements vscode.LanguageModelChatProvide
 				// Handle different chunk types
 				if (chunk.type === 'prompt_progress') {
 					const threshold = getPromptProgressStatusBarThresholdSeconds();
+					const minElapsed = getMinPromptProgressElapsedMs();
 					const result = estimatePromptProgress(
 						{ total: chunk.total, processed: chunk.processed, time_ms: chunk.time_ms },
-						threshold
+						threshold,
+						minElapsed
 					);
 					const shouldShowOrUpdate = result.showStatusBar || promptProgressShown;
 					const msg =
@@ -461,9 +463,11 @@ export class LlamaCopilotChatProvider implements vscode.LanguageModelChatProvide
 				// Handle different chunk types
 				if (chunk.type === 'prompt_progress') {
 					const threshold = getPromptProgressStatusBarThresholdSeconds();
+					const minElapsed = getMinPromptProgressElapsedMs();
 					const result = estimatePromptProgress(
 						{ total: chunk.total, processed: chunk.processed, time_ms: chunk.time_ms },
-						threshold
+						threshold,
+						minElapsed
 					);
 					const shouldShowOrUpdate = result.showStatusBar || promptProgressShown;
 					const msg =


### PR DESCRIPTION
Add a configurable minimum elapsed time before showing prompt progress. Introduces a new setting (llamaCopilot.minPromptProgressElapsedMs, default 10000 ms).